### PR TITLE
Patch `nonce` as we do not require a value

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -175,6 +175,9 @@ module OmniAuth
 
           _id_token = decode_id_token _access_token.id_token, key
 
+          # TODO: Temporary patch for setting `nonce` to `nil`
+          _id_token.nonce = nil
+
           _id_token.verify!(
               issuer: options.issuer,
               client_id: client_options.identifier,


### PR DESCRIPTION
* This is a temporary solution that allows us to move past the
  mobile authentication flow between Simple Auth, OpenIDConnect,
  and the internal authentication system based upon House of Cards